### PR TITLE
カテゴリー　画像表示　修正

### DIFF
--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -17,7 +17,7 @@
                     SOLD
               %figure.list--image
                 - product.images.each do |image|
-                  = image_tag image.image.url, class: "item-image"
+                  = image_tag product.images[0].image.to_s, class: "item-image"
               .list--detail
                 %h3.name
                   = product.name


### PR DESCRIPTION
# what
カテゴリーの詳細ページの画像を1枚目に投稿した画像に修正
# why
トップページの表示と合わせた方が見やすいため